### PR TITLE
remove obsolete SslTransportLayerTest.testUnsupportedTLSVersion test

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
@@ -314,23 +314,6 @@ public class SslTransportLayerTest {
     }
     
     /**
-     * Tests that connections cannot be made with unsupported TLS versions
-     */
-    @Test
-    public void testUnsupportedTLSVersion() throws Exception {
-        String node = "0";
-        sslServerConfigs.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, Arrays.asList("TLSv1.2"));
-        createEchoServer(sslServerConfigs);
-        
-        sslClientConfigs.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, Arrays.asList("TLSv1.1"));
-        createSelector(sslClientConfigs);
-        InetSocketAddress addr = new InetSocketAddress("localhost", server.port);
-        selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
-
-        waitForChannelClose(node);
-    }
-    
-    /**
      * Tests that connections cannot be made with unsupported TLS cipher suites
      */
     @Test


### PR DESCRIPTION
Java updates for >= 1.8 disabled supports for TLS v1 and TLS v1.1 protocols. As a result a test case is failing.
JDK change impacted upstream Kafka mirror as well. Upstream repo [fixed it by removing obsolete test](https://github.com/apache/kafka/commit/12aa595e17c495a1650d8da349c8ef69f787ebe8)

This PR reflecting the same change in our fork to run builds.